### PR TITLE
Fix for csv files using \r\n on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ campaign.add_well(name="well_2", radius=0.1, coordinates=(2., 2.))
 campaign.add_well(name="well_3", radius=0.1, coordinates=(-2., -1.))
 
 ### generate artificial drawdown data with the Theis solution
-prate = -1e-4
+rate = -1e-4
 time = np.geomspace(10, 7200, 10)
 transmissivity = 1e-4
 storage = 1e-4
@@ -61,16 +61,16 @@ rad = [
 drawdown = ana.theis(
     rad=rad,
     time=time,
-    T=transmissivity,
-    S=storage,
-    Qw=prate,
+    transmissivity=transmissivity,
+    storage=storage,
+    rate=rate,
 )
 
 ### create a pumping test at well_0
 pumptest = wtp.data.PumpingTest(
     name="well_0",
     pumpingwell="well_0",
-    pumpingrate=prate,
+    pumpingrate=rate,
     description="Artificial pump test with Theis",
 )
 

--- a/examples/01_create.py
+++ b/examples/01_create.py
@@ -14,7 +14,7 @@ campaign.add_well(name="well_2", radius=0.1, coordinates=(2., 2.))
 campaign.add_well(name="well_3", radius=0.1, coordinates=(-2., -1.))
 
 ### generate artificial drawdown data with the Theis solution
-prate = -1e-4
+rate = -1e-4
 time = np.geomspace(10, 7200, 10)
 transmissivity = 1e-4
 storage = 1e-4
@@ -27,16 +27,16 @@ rad = [
 drawdown = ana.theis(
     rad=rad,
     time=time,
-    T=transmissivity,
-    S=storage,
-    Qw=prate,
+    transmissivity=transmissivity,
+    storage=storage,
+    rate=rate,
 )
 
 ### create a pumping test at well_0
 pumptest = wtp.data.PumpingTest(
     name="well_0",
     pumpingwell="well_0",
-    pumpingrate=prate,
+    pumpingrate=rate,
     description="Artificial pump test with Theis",
 )
 

--- a/welltestpy/data/campaignlib.py
+++ b/welltestpy/data/campaignlib.py
@@ -142,7 +142,7 @@ class FieldSite(object):
         # write the csv-file
         # with open(patht+name[:-4]+".csv", 'w') as csvf:
         with open(os.path.join(patht, "info.csv"), "w") as csvf:
-            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC)
+            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
             writer.writerow(["Fieldsite"])
             writer.writerow(["name", self.name])
             writer.writerow(["description", self.description])
@@ -532,7 +532,7 @@ class Campaign(object):
         # write the csv-file
         # with open(patht+name[:-4]+".csv", 'w') as csvf:
         with open(os.path.join(patht, "info.csv"), "w") as csvf:
-            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC)
+            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
             writer.writerow(["Campaign"])
             writer.writerow(["name", self.name])
             writer.writerow(["description", self.description])

--- a/welltestpy/data/testslib.py
+++ b/welltestpy/data/testslib.py
@@ -448,7 +448,7 @@ class PumpingTest(Test):
         # write the csv-file
         # with open(patht+name[:-4]+".csv", 'w') as csvf:
         with open(os.path.join(patht, "info.csv"), "w") as csvf:
-            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC)
+            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
             writer.writerow(["Testtype", "PumpingTest"])
             writer.writerow(["name", self.name])
             writer.writerow(["description", self.description])

--- a/welltestpy/data/varlib.py
+++ b/welltestpy/data/varlib.py
@@ -196,7 +196,7 @@ class Variable(object):
         file_path = os.path.join(path, name)
         # write the csv-file
         with open(file_path, "w") as csvf:
-            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC)
+            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
             writer.writerow(["Variable"])
             writer.writerow(["name", self.name])
             writer.writerow(["symbol", self.symbol])
@@ -683,7 +683,7 @@ class Observation(object):
         # write the csv-file
         # with open(patht+name[:-4]+".csv", 'w') as csvf:
         with open(os.path.join(patht, "info.csv"), "w") as csvf:
-            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC)
+            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
             writer.writerow(["Observation"])
             writer.writerow(["name", self.name])
             writer.writerow(["state", self.state])
@@ -1091,7 +1091,7 @@ class Well(object):
         # write the csv-file
         # with open(patht+name[:-4]+".csv", 'w') as csvf:
         with open(os.path.join(patht, "info.csv"), "w") as csvf:
-            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC)
+            writer = csv.writer(csvf, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
             writer.writerow(["Well"])
             writer.writerow(["name", self.name])
             # define names for the variable-files


### PR DESCRIPTION
Running the examples on Windows leads to many errors because the CSV files are being written with ``\r\n`` line endings.

This PR contains a simple fix of using ``csv.writer(..., lineterminator='\n')``, which brings Windows behaviour in line with **nix.