### PR TITLE
Estimator: fit transformation selectable

### DIFF
--- a/tests/test_welltestpy.py
+++ b/tests/test_welltestpy.py
@@ -79,11 +79,15 @@ class TestWTP(unittest.TestCase):
         estimation.run()
         res = estimation.estimated_para
         estimation.sensitivity()
-        self.assertAlmostEqual(np.exp(res["transmissivity"]), self.transmissivity, 2)
+        self.assertAlmostEqual(
+            np.exp(res["transmissivity"]), self.transmissivity, 2
+        )
         self.assertAlmostEqual(np.exp(res["storage"]), self.storage, 2)
         sens = estimation.sens
         for s_typ in self.s_types:
-            self.assertTrue(sens[s_typ]["transmissivity"] > sens[s_typ]["storage"])
+            self.assertTrue(
+                sens[s_typ]["transmissivity"] > sens[s_typ]["storage"]
+            )
 
     def test_est_thiem(self):
         campaign = wtp.load_campaign("Cmp_UFZ-campaign.cmp")
@@ -94,10 +98,14 @@ class TestWTP(unittest.TestCase):
         # we need a dummy parameter to estimate sensitivity
         estimation.gen_setup(dummy=True)
         estimation.sensitivity()
-        self.assertAlmostEqual(np.exp(res["transmissivity"]), self.transmissivity, 2)
+        self.assertAlmostEqual(
+            np.exp(res["transmissivity"]), self.transmissivity, 2
+        )
         sens = estimation.sens
         for s_typ in self.s_types:
-            self.assertTrue(sens[s_typ]["transmissivity"] > sens[s_typ]["dummy"])
+            self.assertTrue(
+                sens[s_typ]["transmissivity"] > sens[s_typ]["dummy"]
+            )
 
     def test_est_ext_thiem2D(self):
         campaign = wtp.load_campaign("Cmp_UFZ-campaign.cmp")
@@ -107,7 +115,9 @@ class TestWTP(unittest.TestCase):
         estimation.run()
         res = estimation.estimated_para
         estimation.sensitivity()
-        self.assertAlmostEqual(np.exp(res["trans_gmean"]), self.transmissivity, 2)
+        self.assertAlmostEqual(
+            np.exp(res["trans_gmean"]), self.transmissivity, 2
+        )
         self.assertAlmostEqual(res["var"], 0.0, 0)
         sens = estimation.sens
         for s_typ in self.s_types:

--- a/tests/test_welltestpy.py
+++ b/tests/test_welltestpy.py
@@ -79,11 +79,11 @@ class TestWTP(unittest.TestCase):
         estimation.run()
         res = estimation.estimated_para
         estimation.sensitivity()
-        self.assertAlmostEqual(np.exp(res["mu"]), self.transmissivity, 2)
-        self.assertAlmostEqual(np.exp(res["lnS"]), self.storage, 2)
+        self.assertAlmostEqual(np.exp(res["transmissivity"]), self.transmissivity, 2)
+        self.assertAlmostEqual(np.exp(res["storage"]), self.storage, 2)
         sens = estimation.sens
         for s_typ in self.s_types:
-            self.assertTrue(sens[s_typ]["mu"] > sens[s_typ]["lnS"])
+            self.assertTrue(sens[s_typ]["transmissivity"] > sens[s_typ]["storage"])
 
     def test_est_thiem(self):
         campaign = wtp.load_campaign("Cmp_UFZ-campaign.cmp")
@@ -94,10 +94,10 @@ class TestWTP(unittest.TestCase):
         # we need a dummy parameter to estimate sensitivity
         estimation.gen_setup(dummy=True)
         estimation.sensitivity()
-        self.assertAlmostEqual(np.exp(res["mu"]), self.transmissivity, 2)
+        self.assertAlmostEqual(np.exp(res["transmissivity"]), self.transmissivity, 2)
         sens = estimation.sens
         for s_typ in self.s_types:
-            self.assertTrue(sens[s_typ]["mu"] > sens[s_typ]["dummy"])
+            self.assertTrue(sens[s_typ]["transmissivity"] > sens[s_typ]["dummy"])
 
     def test_est_ext_thiem2D(self):
         campaign = wtp.load_campaign("Cmp_UFZ-campaign.cmp")
@@ -107,11 +107,11 @@ class TestWTP(unittest.TestCase):
         estimation.run()
         res = estimation.estimated_para
         estimation.sensitivity()
-        self.assertAlmostEqual(np.exp(res["mu"]), self.transmissivity, 2)
+        self.assertAlmostEqual(np.exp(res["trans_gmean"]), self.transmissivity, 2)
         self.assertAlmostEqual(res["var"], 0.0, 0)
         sens = estimation.sens
         for s_typ in self.s_types:
-            self.assertTrue(sens[s_typ]["mu"] > sens[s_typ]["var"])
+            self.assertTrue(sens[s_typ]["trans_gmean"] > sens[s_typ]["var"])
             self.assertTrue(sens[s_typ]["var"] > sens[s_typ]["len_scale"])
 
     # def test_est_ext_thiem3D(self):
@@ -122,7 +122,7 @@ class TestWTP(unittest.TestCase):
     #     estimation.run()
     #     res = estimation.estimated_para
     #     estimation.sensitivity()
-    #     self.assertAlmostEqual(np.exp(res["mu"]), self.transmissivity, 2)
+    #     self.assertAlmostEqual(np.exp(res["cond_gmean"]), self.transmissivity, 2)
     #     self.assertAlmostEqual(res["var"], 0.0, 0)
 
     def test_triangulate(self):

--- a/welltestpy/estimate/estimators.py
+++ b/welltestpy/estimate/estimators.py
@@ -561,7 +561,11 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"trans_gmean": (1e-7, 2e-1), "var": (0, 10), "len_scale": (1, 50)}
+        def_ranges = {
+            "trans_gmean": (1e-7, 2e-1),
+            "var": (0, 10),
+            "len_scale": (1, 50),
+        }
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
@@ -654,7 +658,11 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"trans_gmean": (1e-7, 2e-1), "var": (0, 10), "len_scale": (1, 50)}
+        def_ranges = {
+            "trans_gmean": (1e-7, 2e-1),
+            "var": (0, 10),
+            "len_scale": (1, 50),
+        }
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)

--- a/welltestpy/estimate/estimators.py
+++ b/welltestpy/estimate/estimators.py
@@ -53,13 +53,25 @@ class ExtTheis3D(transient_lib.TransientPumping):
         parameters
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -77,27 +89,30 @@ class ExtTheis3D(transient_lib.TransientPumping):
         campaign,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
         def_ranges = {
-            "mu": (-16, -2),
+            "cond_gmean": (1e-7, 2e-1),
             "var": (0, 10),
             "len_scale": (1, 50),
-            "lnS": (-13, -1),
+            "storage": (2e-6, 4e-1),
             "anis": (0, 1),
         }
-        val_ranges = {} if val_ranges is None else val_ranges
-        val_fix = {"lat_ext": 1.0} if val_fix is None else val_fix
+        val_ranges = val_ranges or {}
+        val_fix = val_fix or {"lat_ext": 1.0}
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log", "lnS": "log"}
-        val_kw_names = {"mu": "cond_gmean", "lnS": "storage"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("cond_gmean", "log")
+        val_fit_type.setdefault("storage", "log")
         val_plot_names = {
-            "mu": r"$\mu$",
+            "cond_gmean": "$K_G$",
             "var": r"$\sigma^2$",
             "len_scale": r"$\ell$",
-            "lnS": r"$\ln(S)$",
+            "storage": "$S$",
             "anis": "$e$",
         }
         super().__init__(
@@ -106,8 +121,8 @@ class ExtTheis3D(transient_lib.TransientPumping):
             type_curve=ana.ext_theis_3d,
             val_ranges=val_ranges,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -134,13 +149,25 @@ class ExtTheis2D(transient_lib.TransientPumping):
         paramters
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -158,25 +185,28 @@ class ExtTheis2D(transient_lib.TransientPumping):
         campaign,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
         def_ranges = {
-            "mu": (-16, -2),
+            "trans_gmean": (1e-7, 2e-1),
             "var": (0, 10),
             "len_scale": (1, 50),
-            "lnS": (-13, -1),
+            "storage": (2e-6, 4e-1),
         }
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log", "lnS": "log"}
-        val_kw_names = {"mu": "trans_gmean", "lnS": "storage"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("trans_gmean", "log")
+        val_fit_type.setdefault("storage", "log")
         val_plot_names = {
-            "mu": r"$\mu$",
+            "trans_gmean": "$T_G$",
             "var": r"$\sigma^2$",
             "len_scale": r"$\ell$",
-            "lnS": r"$\ln(S)$",
+            "storage": "$S$",
         }
         super().__init__(
             name=name,
@@ -184,8 +214,8 @@ class ExtTheis2D(transient_lib.TransientPumping):
             type_curve=ana.ext_theis_2d,
             val_ranges=val_ranges,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -212,13 +242,25 @@ class Neuman2004(transient_lib.TransientPumping):
         parameters
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -236,25 +278,28 @@ class Neuman2004(transient_lib.TransientPumping):
         campaign,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
         def_ranges = {
-            "mu": (-16, -2),
+            "trans_gmean": (1e-7, 2e-1),
             "var": (0, 10),
             "len_scale": (1, 50),
-            "lnS": (-13, -1),
+            "storage": (2e-6, 4e-1),
         }
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log", "lnS": "log"}
-        val_kw_names = {"mu": "trans_gmean", "lnS": "storage"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("trans_gmean", "log")
+        val_fit_type.setdefault("storage", "log")
         val_plot_names = {
-            "mu": r"$\mu$",
+            "trans_gmean": "$T_G$",
             "var": r"$\sigma^2$",
             "len_scale": r"$\ell$",
-            "lnS": r"$\ln(S)$",
+            "storage": "$S$",
         }
         super().__init__(
             name=name,
@@ -262,8 +307,8 @@ class Neuman2004(transient_lib.TransientPumping):
             type_curve=ana.neuman2004,
             val_ranges=val_ranges,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -288,13 +333,25 @@ class Theis(transient_lib.TransientPumping):
         parameters
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -312,24 +369,27 @@ class Theis(transient_lib.TransientPumping):
         campaign,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"mu": (-16, -2), "lnS": (-13, -1)}
+        def_ranges = {"transmissivity": (1e-7, 2e-1), "storage": (2e-6, 4e-1)}
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log", "lnS": "log"}
-        val_kw_names = {"mu": "transmissivity", "lnS": "storage"}
-        val_plot_names = {"mu": r"$\ln(T)$", "lnS": r"$\ln(S)$"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("transmissivity", "log")
+        val_fit_type.setdefault("storage", "log")
+        val_plot_names = {"transmissivity": "$T$", "storage": "$S$"}
         super().__init__(
             name=name,
             campaign=campaign,
             type_curve=ana.theis,
             val_ranges=val_ranges,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -360,13 +420,25 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         Default: True
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -385,11 +457,13 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         make_steady=True,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
         def_ranges = {
-            "mu": (-16, -2),
+            "cond_gmean": (1e-7, 2e-1),
             "var": (0, 10),
             "len_scale": (1, 50),
             "anis": (0, 1),
@@ -398,10 +472,10 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         val_fix = {"lat_ext": 1.0} if val_fix is None else val_fix
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log"}
-        val_kw_names = {"mu": "cond_gmean"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("cond_gmean", "log")
         val_plot_names = {
-            "mu": r"$\mu$",
+            "cond_gmean": "$K_G$",
             "var": r"$\sigma^2$",
             "len_scale": r"$\ell$",
             "anis": "$e$",
@@ -413,8 +487,8 @@ class ExtThiem3D(steady_lib.SteadyPumping):
             val_ranges=val_ranges,
             make_steady=make_steady,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -445,13 +519,25 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         Default: True
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -470,17 +556,19 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         make_steady=True,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"mu": (-16, -2), "var": (0, 10), "len_scale": (1, 50)}
+        def_ranges = {"trans_gmean": (1e-7, 2e-1), "var": (0, 10), "len_scale": (1, 50)}
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log"}
-        val_kw_names = {"mu": "trans_gmean"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("trans_gmean", "log")
         val_plot_names = {
-            "mu": r"$\mu$",
+            "trans_gmean": "$T_G$",
             "var": r"$\sigma^2$",
             "len_scale": r"$\ell$",
         }
@@ -491,8 +579,8 @@ class ExtThiem2D(steady_lib.SteadyPumping):
             type_curve=ana.ext_thiem_2d,
             val_ranges=val_ranges,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -524,13 +612,25 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         Default: True
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -549,17 +649,19 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         make_steady=True,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"mu": (-16, -2), "var": (0, 10), "len_scale": (1, 50)}
+        def_ranges = {"trans_gmean": (1e-7, 2e-1), "var": (0, 10), "len_scale": (1, 50)}
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log"}
-        val_kw_names = {"mu": "trans_gmean"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("trans_gmean", "log")
         val_plot_names = {
-            "mu": r"$\mu$",
+            "trans_gmean": "$T_G$",
             "var": r"$\sigma^2$",
             "len_scale": r"$\ell$",
         }
@@ -570,8 +672,8 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
             type_curve=ana.neuman2004_steady,
             val_ranges=val_ranges,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,
@@ -600,13 +702,25 @@ class Thiem(steady_lib.SteadyPumping):
         Default: True
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
+        Default: None
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
+        Default: None
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     testinclude : :class:`dict`, optional
         Dictionary of which tests should be included. If ``None`` is given,
@@ -625,16 +739,18 @@ class Thiem(steady_lib.SteadyPumping):
         make_steady=True,
         val_ranges=None,
         val_fix=None,
+        val_fit_type=None,
+        val_fit_name=None,
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"mu": (-16, -2)}
+        def_ranges = {"transmissivity": (1e-7, 2e-1)}
         val_ranges = {} if val_ranges is None else val_ranges
         for def_name, def_val in def_ranges.items():
             val_ranges.setdefault(def_name, def_val)
-        fit_type = {"mu": "log"}
-        val_kw_names = {"mu": "transmissivity"}
-        val_plot_names = {"mu": r"$\ln(T)$"}
+        val_fit_type = val_fit_type or {}
+        val_fit_type.setdefault("transmissivity", "log")
+        val_plot_names = {"transmissivity": "$T$"}
         super().__init__(
             name=name,
             campaign=campaign,
@@ -642,8 +758,8 @@ class Thiem(steady_lib.SteadyPumping):
             val_ranges=val_ranges,
             make_steady=make_steady,
             val_fix=val_fix,
-            fit_type=fit_type,
-            val_kw_names=val_kw_names,
+            val_fit_type=val_fit_type,
+            val_fit_name=val_fit_name,
             val_plot_names=val_plot_names,
             testinclude=testinclude,
             generate=generate,

--- a/welltestpy/estimate/estimators.py
+++ b/welltestpy/estimate/estimators.py
@@ -33,16 +33,20 @@ __all__ = [
 ]
 
 
-# ext_theis_3D
-
-
 class ExtTheis3D(transient_lib.TransientPumping):
     """Class for an estimation of stochastic subsurface parameters.
 
     With this class you can run an estimation of statistical subsurface
-    parameters. It utilizes the extended theis solution in 3D which assumes
-    a log-normal distributed transmissivity field with a gaussian correlation
+    parameters. It utilizes the extended Theis solution in 3D which assumes
+    a log-normal distributed conductivity field with a gaussian correlation
     function and an anisotropy ratio 0 < e <= 1.
+
+    Available values for fitting:
+    - ``cond_gmean``: geometric mean conductivity
+    - ``var``: variance of log-conductivity
+    - ``len_scale``: correlation length scale of log-conductivity
+    - ``anis``: anisotropy between horizontal and vertical correlation length
+    - ``storage``: storage
 
     Parameters
     ----------
@@ -51,15 +55,16 @@ class ExtTheis3D(transient_lib.TransientPumping):
     campaign : :class:`welltestpy.data.Campaign`
         The pumping test campaign which should be used to estimate the
         parameters
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -68,7 +73,7 @@ class ExtTheis3D(transient_lib.TransientPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -83,6 +88,15 @@ class ExtTheis3D(transient_lib.TransientPumping):
         Default: ``False``
     """
 
+    default_ranges = {
+        "cond_gmean": (1e-7, 2e-1),
+        "var": (0, 10),
+        "len_scale": (1, 50),
+        "storage": (2e-6, 4e-1),
+        "anis": (0, 1),
+    }
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -94,16 +108,10 @@ class ExtTheis3D(transient_lib.TransientPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {
-            "cond_gmean": (1e-7, 2e-1),
-            "var": (0, 10),
-            "len_scale": (1, 50),
-            "storage": (2e-6, 4e-1),
-            "anis": (0, 1),
-        }
         val_ranges = val_ranges or {}
-        val_fix = val_fix or {"lat_ext": 1.0}
-        for def_name, def_val in def_ranges.items():
+        val_fix = val_fix or {}
+        val_fix.setdefault("lat_ext", 1.0)
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("cond_gmean", "log")
@@ -129,16 +137,19 @@ class ExtTheis3D(transient_lib.TransientPumping):
         )
 
 
-# ext_theis_2D
-
-
 class ExtTheis2D(transient_lib.TransientPumping):
     """Class for an estimation of stochastic subsurface parameters.
 
     With this class you can run an estimation of statistical subsurface
-    parameters. It utilizes the extended theis solution in 2D which assumes
+    parameters. It utilizes the extended Theis solution in 2D which assumes
     a log-normal distributed transmissivity field with a gaussian correlation
     function.
+
+    Available values for fitting:
+    - ``trans_gmean``: geometric mean transmissivity
+    - ``var``: variance of log-transmissivity
+    - ``len_scale``: correlation length scale of log-transmissivity
+    - ``storage``: storage
 
     Parameters
     ----------
@@ -147,15 +158,16 @@ class ExtTheis2D(transient_lib.TransientPumping):
     campaign : :class:`welltestpy.data.Campaign`
         The pumping test campaign which should be used to estimate the
         paramters
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -164,7 +176,7 @@ class ExtTheis2D(transient_lib.TransientPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -179,6 +191,14 @@ class ExtTheis2D(transient_lib.TransientPumping):
         Default: ``False``
     """
 
+    default_ranges = {
+        "trans_gmean": (1e-7, 2e-1),
+        "var": (0, 10),
+        "len_scale": (1, 50),
+        "storage": (2e-6, 4e-1),
+    }
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -190,14 +210,8 @@ class ExtTheis2D(transient_lib.TransientPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {
-            "trans_gmean": (1e-7, 2e-1),
-            "var": (0, 10),
-            "len_scale": (1, 50),
-            "storage": (2e-6, 4e-1),
-        }
-        val_ranges = {} if val_ranges is None else val_ranges
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("trans_gmean", "log")
@@ -222,9 +236,6 @@ class ExtTheis2D(transient_lib.TransientPumping):
         )
 
 
-# neuman 2004
-
-
 class Neuman2004(transient_lib.TransientPumping):
     """Class for an estimation of stochastic subsurface parameters.
 
@@ -233,6 +244,12 @@ class Neuman2004(transient_lib.TransientPumping):
     which assumes a log-normal distributed transmissivity field
     with an exponential correlation function.
 
+    Available values for fitting:
+    - ``trans_gmean``: geometric mean transmissivity
+    - ``var``: variance of log-transmissivity
+    - ``len_scale``: correlation length scale of log-transmissivity
+    - ``storage``: storage
+
     Parameters
     ----------
     name : :class:`str`
@@ -240,15 +257,16 @@ class Neuman2004(transient_lib.TransientPumping):
     campaign : :class:`welltestpy.data.Campaign`
         The pumping test campaign which should be used to estimate the
         parameters
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -257,7 +275,7 @@ class Neuman2004(transient_lib.TransientPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -272,6 +290,14 @@ class Neuman2004(transient_lib.TransientPumping):
         Default: ``False``
     """
 
+    default_ranges = {
+        "trans_gmean": (1e-7, 2e-1),
+        "var": (0, 10),
+        "len_scale": (1, 50),
+        "storage": (2e-6, 4e-1),
+    }
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -283,14 +309,8 @@ class Neuman2004(transient_lib.TransientPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {
-            "trans_gmean": (1e-7, 2e-1),
-            "var": (0, 10),
-            "len_scale": (1, 50),
-            "storage": (2e-6, 4e-1),
-        }
-        val_ranges = {} if val_ranges is None else val_ranges
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("trans_gmean", "log")
@@ -315,14 +335,15 @@ class Neuman2004(transient_lib.TransientPumping):
         )
 
 
-# theis
-
-
 class Theis(transient_lib.TransientPumping):
     """Class for an estimation of homogeneous subsurface parameters.
 
     With this class you can run an estimation of homogeneous subsurface
-    parameters. It utilizes the theis solution.
+    parameters. It utilizes the Theis solution.
+
+    Available values for fitting:
+    - ``transmissivity``: transmissivity
+    - ``storage``: storage
 
     Parameters
     ----------
@@ -331,15 +352,16 @@ class Theis(transient_lib.TransientPumping):
     campaign : :class:`welltestpy.data.Campaign`
         The pumping test campaign which should be used to estimate the
         parameters
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -348,7 +370,7 @@ class Theis(transient_lib.TransientPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -363,6 +385,9 @@ class Theis(transient_lib.TransientPumping):
         Default: ``False``
     """
 
+    default_ranges = {"transmissivity": (1e-7, 2e-1), "storage": (2e-6, 4e-1)}
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -374,9 +399,8 @@ class Theis(transient_lib.TransientPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"transmissivity": (1e-7, 2e-1), "storage": (2e-6, 4e-1)}
-        val_ranges = {} if val_ranges is None else val_ranges
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("transmissivity", "log")
@@ -396,16 +420,19 @@ class Theis(transient_lib.TransientPumping):
         )
 
 
-# ext_thiem_3d
-
-
 class ExtThiem3D(steady_lib.SteadyPumping):
     """Class for an estimation of stochastic subsurface parameters.
 
     With this class you can run an estimation of statistical subsurface
-    parameters. It utilizes the extended thiem solution in 3D which assumes
-    a log-normal distributed transmissivity field with a gaussian correlation
+    parameters. It utilizes the extended Thiem solution in 3D which assumes
+    a log-normal distributed conductivity field with a gaussian correlation
     function and an anisotropy ratio 0 < e <= 1.
+
+    Available values for fitting:
+    - ``cond_gmean``: geometric mean conductivity
+    - ``var``: variance of log-conductivity
+    - ``len_scale``: correlation length scale of log-conductivity
+    - ``anis``: anisotropy between horizontal and vertical correlation length
 
     Parameters
     ----------
@@ -418,24 +445,25 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         State if the tests should be converted to steady observations.
         See: :any:`PumpingTest.make_steady`.
         Default: True
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, values will be fitted linear and logarithmic.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -450,6 +478,14 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         Default: ``False``
     """
 
+    default_ranges = {
+        "cond_gmean": (1e-7, 2e-1),
+        "var": (0, 10),
+        "len_scale": (1, 50),
+        "anis": (0, 1),
+    }
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -462,15 +498,10 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {
-            "cond_gmean": (1e-7, 2e-1),
-            "var": (0, 10),
-            "len_scale": (1, 50),
-            "anis": (0, 1),
-        }
-        val_ranges = {} if val_ranges is None else val_ranges
-        val_fix = {"lat_ext": 1.0} if val_fix is None else val_fix
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        val_fix = val_fix or {}
+        val_fix.setdefault("lat_ext", 1.0)
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("cond_gmean", "log")
@@ -495,16 +526,18 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         )
 
 
-# ext_thiem_2D
-
-
 class ExtThiem2D(steady_lib.SteadyPumping):
     """Class for an estimation of stochastic subsurface parameters.
 
     With this class you can run an estimation of statistical subsurface
-    parameters. It utilizes the extended thiem solution in 2D which assumes
+    parameters. It utilizes the extended Thiem solution in 2D which assumes
     a log-normal distributed transmissivity field with a gaussian correlation
     function.
+
+    Available values for fitting:
+    - ``trans_gmean``: geometric mean transmissivity
+    - ``var``: variance of log-transmissivity
+    - ``len_scale``: correlation length scale of log-transmissivity
 
     Parameters
     ----------
@@ -517,15 +550,16 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         State if the tests should be converted to steady observations.
         See: :any:`PumpingTest.make_steady`.
         Default: True
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -534,7 +568,7 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -549,6 +583,13 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         Default: ``False``
     """
 
+    default_ranges = {
+        "trans_gmean": (1e-7, 2e-1),
+        "var": (0, 10),
+        "len_scale": (1, 50),
+    }
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -561,13 +602,8 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {
-            "trans_gmean": (1e-7, 2e-1),
-            "var": (0, 10),
-            "len_scale": (1, 50),
-        }
-        val_ranges = {} if val_ranges is None else val_ranges
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("trans_gmean", "log")
@@ -591,9 +627,6 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         )
 
 
-# neuman 2004 steady
-
-
 class Neuman2004Steady(steady_lib.SteadyPumping):
     """Class for an estimation of stochastic subsurface parameters.
 
@@ -602,6 +635,11 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
     It utilizes the apparent Transmissivity from Neuman 2004
     which assumes a log-normal distributed transmissivity field
     with an exponential correlation function.
+
+    Available values for fitting:
+    - ``trans_gmean``: geometric mean transmissivity
+    - ``var``: variance of log-transmissivity
+    - ``len_scale``: correlation length scale of log-transmissivity
 
     Parameters
     ----------
@@ -614,15 +652,16 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         State if the tests should be converted to steady observations.
         See: :any:`PumpingTest.make_steady`.
         Default: True
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -631,7 +670,7 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -646,6 +685,13 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         Default: ``False``
     """
 
+    default_ranges = {
+        "trans_gmean": (1e-7, 2e-1),
+        "var": (0, 10),
+        "len_scale": (1, 50),
+    }
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -658,13 +704,8 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {
-            "trans_gmean": (1e-7, 2e-1),
-            "var": (0, 10),
-            "len_scale": (1, 50),
-        }
-        val_ranges = {} if val_ranges is None else val_ranges
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("trans_gmean", "log")
@@ -688,14 +729,14 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         )
 
 
-# thiem
-
-
 class Thiem(steady_lib.SteadyPumping):
     """Class for an estimation of homogeneous subsurface parameters.
 
     With this class you can run an estimation of homogeneous subsurface
-    parameters. It utilizes the thiem solution.
+    parameters. It utilizes the Thiem solution.
+
+    Available values for fitting:
+    - ``transmissivity``: transmissivity
 
     Parameters
     ----------
@@ -708,15 +749,16 @@ class Thiem(steady_lib.SteadyPumping):
         State if the tests should be converted to steady observations.
         See: :any:`PumpingTest.make_steady`.
         Default: True
-    val_ranges : :class:`dict`
+    val_ranges : :class:`dict`, optional
         Dictionary containing the fit-ranges for each value in the type-curve.
         Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
-    val_fix : :class:`dict` or :any:`None`
+        Will default to `default_ranges`
+    val_fix : :class:`dict`, optional
         Dictionary containing fixed values for the type-curve.
         Names should be as in the type-curve signature.
         Default: None
-    val_fit_type : :class:`dict` or :any:`None`
+    val_fit_type : :class:`dict`, optional
         Dictionary containing fitting transformation type for each value.
         Names should be as in the type-curve signature.
         val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
@@ -725,7 +767,7 @@ class Thiem(steady_lib.SteadyPumping):
         "log" is for example equivalent to ``(np.log, np.exp)``.
         By default, values will be fitted linear.
         Default: None
-    val_fit_name : :class:`dict` or :any:`None`
+    val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
         Will be the val_fit_type string if it is a predefined one,
         or ``f`` if it is a given callable as default for each value.
@@ -740,6 +782,9 @@ class Thiem(steady_lib.SteadyPumping):
         Default: ``False``
     """
 
+    default_ranges = {"transmissivity": (1e-7, 2e-1)}
+    """:class:`dict`: Default value ranges for the estimator."""
+
     def __init__(
         self,
         name,
@@ -752,9 +797,8 @@ class Thiem(steady_lib.SteadyPumping):
         testinclude=None,
         generate=False,
     ):
-        def_ranges = {"transmissivity": (1e-7, 2e-1)}
-        val_ranges = {} if val_ranges is None else val_ranges
-        for def_name, def_val in def_ranges.items():
+        val_ranges = val_ranges or {}
+        for def_name, def_val in self.default_ranges.items():
             val_ranges.setdefault(def_name, def_val)
         val_fit_type = val_fit_type or {}
         val_fit_type.setdefault("transmissivity", "log")

--- a/welltestpy/estimate/estimators.py
+++ b/welltestpy/estimate/estimators.py
@@ -71,7 +71,8 @@ class ExtTheis3D(transient_lib.TransientPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, conductivity and storage will be fitted logarithmically
+        and other values linearly.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -174,7 +175,8 @@ class ExtTheis2D(transient_lib.TransientPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, transmissivity and storage will be fitted logarithmically
+        and other values linearly.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -273,7 +275,8 @@ class Neuman2004(transient_lib.TransientPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, transmissivity and storage will be fitted logarithmically
+        and other values linearly.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -368,7 +371,7 @@ class Theis(transient_lib.TransientPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, transmissivity and storage will be fitted logarithmically.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -461,7 +464,8 @@ class ExtThiem3D(steady_lib.SteadyPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear and logarithmic.
+        By default, conductivity will be fitted logarithmically
+        and other values linearly.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -566,7 +570,8 @@ class ExtThiem2D(steady_lib.SteadyPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, transmissivity will be fitted logarithmically
+        and other values linearly.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -668,7 +673,8 @@ class Neuman2004Steady(steady_lib.SteadyPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, transmissivity will be fitted logarithmically
+        and other values linearly.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.
@@ -765,7 +771,7 @@ class Thiem(steady_lib.SteadyPumping):
         or a tuple of two callable functions where the
         first is the transformation and the second is its inverse.
         "log" is for example equivalent to ``(np.log, np.exp)``.
-        By default, values will be fitted linear.
+        By default, transmissivity will be fitted logarithmically.
         Default: None
     val_fit_name : :class:`dict`, optional
         Display name of the fitting transformation.

--- a/welltestpy/estimate/spotpylib.py
+++ b/welltestpy/estimate/spotpylib.py
@@ -67,7 +67,7 @@ def fast_rep(para_no, infer_fac=4, freq_step=2):
         The frequency step. Default: 2
     """
     return 2 * int(
-        para_no * (1 + 4 * infer_fac ** 2 * (1 + (para_no - 2) * freq_step))
+        para_no * (1 + 4 * infer_fac**2 * (1 + (para_no - 2) * freq_step))
     )
 
 
@@ -152,13 +152,19 @@ class TypeCurve:
             # linear fitting by default
             fit_t = self.val_fit_type.get(val, "lin")
             fit_n = fit_t if fit_t in FIT else "f"
-            self.val_fit_name.setdefault(val, fit_n if fit_n != "lin" else None)
-            self.fit_func[val] = fit_t if _is_callable_tuple(fit_t) else FIT.get(fit_t, None)
+            self.val_fit_name.setdefault(
+                val, fit_n if fit_n != "lin" else None
+            )
+            self.fit_func[val] = (
+                fit_t if _is_callable_tuple(fit_t) else FIT.get(fit_t, None)
+            )
             if not self.fit_func[val]:
                 raise ValueError(f"Fitting transformation for '{val}' missing")
             # apply fitting transformation to ranges
             self.para_dist.append(
-                spotpy.parameter.Uniform(val, *map(self.fit_func[val][0], self.val_ranges[val]))
+                spotpy.parameter.Uniform(
+                    val, *map(self.fit_func[val][0], self.val_ranges[val])
+                )
             )
             self.val_plot_names.setdefault(val, val)
 

--- a/welltestpy/estimate/spotpylib.py
+++ b/welltestpy/estimate/spotpylib.py
@@ -19,21 +19,39 @@ import spotpy
 __all__ = ["TypeCurve", "fast_rep"]
 
 
-# functions for fitting
+def _quad(x):
+    return np.power(x, 2)
+
+
+def _inv(x):
+    return 1.0 / x
+
+
+def _lin(x):
+    return x
+
+
 FIT = {
-    "linear": lambda x: x,
-    "lin": lambda x: x,
-    "logarithmic": np.exp,
-    "log": np.exp,
-    "exponential": np.log,
-    "exp": np.log,
-    "squareroot": lambda x: np.power(x, 2),
-    "sqrt": lambda x: np.power(x, 2),
-    "quadratic": np.sqrt,
-    "quad": np.sqrt,
-    "inverse": lambda x: 1.0 / x,
-    "inv": lambda x: 1.0 / x,
+    "lin": (_lin, _lin),
+    "log": (np.log, np.exp),
+    "exp": (np.exp, np.log),
+    "sqrt": (np.sqrt, _quad),
+    "quad": (_quad, np.sqrt),
+    "inv": (_inv, _inv),
 }
+"""dict: all predefined fitting transformations and their inverse."""
+
+
+def _is_callable_tuple(input):
+    result = False
+    try:
+        length = len(input)
+    except TypeError:
+        length = -1
+    finally:
+        if length == 2:
+            result = all(map(callable, input))
+    return result
 
 
 def fast_rep(para_no, infer_fac=4, freq_step=2):
@@ -57,10 +75,7 @@ class TypeCurve:
     r"""Spotpy class for an estimation of subsurface parameters.
 
     This class fits a given Type Curve to given data.
-    Values will be sampled uniformly in given ranges.
-
-    Fitting values will be done linear, logarithmic or by user specified
-    function.
+    Values will be sampled uniformly in given ranges and with given transformation.
 
     Parameters
     ----------
@@ -70,32 +85,29 @@ class TypeCurve:
         Observed data as array. Will be reshaped to flat array.
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
-        Ranges should be a tuple containing min and max value.
+        Names should be as in the type-curve signature.
+        All values to be estimated should be present here.
+        Ranges should be a tuple containing min and max value: ``(min, max)``.
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Default: None
-    fit_type : :class:`dict` or :any:`None`
-        Dictionary containing fitting type for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
-        fit_type can be "lin", "log" (np.exp(val) will be used)
-        or a callable function.
-        By default, values will be fit linearly.
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
         Default: None
-    val_kw_names : :class:`dict` or :any:`None`
-        Dictionary containing keyword names in the type-curve for each value.
-
-            {value-name: kwargs-name in type_curve}
-
-        This is useful if fitting is not done by linear values.
-        By default, parameter names will be value names.
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     val_plot_names : :class:`dict` or :any:`None`
-        Dictionary containing plottable strings for the parameters.
+        Dictionary containing plotable strings for the parameters.
 
             {value-name: plotting-string}
 
@@ -112,57 +124,55 @@ class TypeCurve:
         data,
         val_ranges,
         val_fix=None,
-        fit_type=None,
-        val_kw_names=None,
+        val_fit_type=None,
+        val_fit_name=None,
         val_plot_names=None,
         dummy=False,
     ):
         self.func = type_curve
-        assert callable(self.func), "type_curve not callable"
-        self.fit_type = {} if fit_type is None else fit_type
-        self.val_kw_names = {} if val_kw_names is None else val_kw_names
-        self.val_plot_names = {} if val_plot_names is None else val_plot_names
-        self.val_ranges = val_ranges
-        assert self.val_ranges, "No ranges given"
-        self.val_fix = {} if val_fix is None else val_fix
-        self.val_fix_kw = {}
-        for fix in self.val_fix:
-            name = self.val_kw_names.get(fix, fix)
-            fit_fix = self.fit_type.get(fix, "lin")
-            fit_fix = fit_fix if callable(fit_fix) else FIT[fit_fix]
-            self.val_fix_kw[name] = fit_fix(self.val_fix[fix])
+        if not callable(self.func):
+            raise ValueError("type_curve not callable")
+        self.val_fit_type = val_fit_type or {}
+        self.val_plot_names = val_plot_names or {}
+        if not isinstance(val_ranges, dict) or not val_ranges:
+            raise ValueError("No ranges given")
+        self.val_ranges = val_ranges.copy()
+        self.val_fix = val_fix or {}
         # if values haven given ranges but should be fixed, remove ranges
         for inter in set(self.val_ranges) & set(self.val_fix):
             del self.val_ranges[inter]
 
-        self.para_names = list(val_ranges)
+        self.para_names = list(self.val_ranges)
         self.para_dist = []
         self.data = np.array(data, dtype=float).reshape(-1)
         self.sim_kwargs = {}
         self.fit_func = {}
-
+        self.val_fit_name = val_fit_name or {}
         for val in self.para_names:
+            # linear fitting by default
+            fit_t = self.val_fit_type.get(val, "lin")
+            fit_n = fit_t if fit_t in FIT else "f"
+            self.val_fit_name.setdefault(val, fit_n if fit_n != "lin" else None)
+            self.fit_func[val] = fit_t if _is_callable_tuple(fit_t) else FIT.get(fit_t, None)
+            if not self.fit_func[val]:
+                raise ValueError(f"Fitting transformation for '{val}' missing")
+            # apply fitting transformation to ranges
             self.para_dist.append(
-                spotpy.parameter.Uniform(val, *self.val_ranges[val])
+                spotpy.parameter.Uniform(val, *map(self.fit_func[val][0], self.val_ranges[val]))
             )
-            fit_t = self.fit_type.get(val, "lin")
-            self.fit_func[val] = fit_t if callable(fit_t) else FIT[fit_t]
-            self.val_kw_names.setdefault(val, val)
             self.val_plot_names.setdefault(val, val)
 
         self.dummy = dummy
         if self.dummy:
             self.para_dist.append(spotpy.parameter.Uniform("dummy", 0, 1))
 
-        self.sim = ft.partial(self.func, **self.val_fix_kw)
+        self.sim = ft.partial(self.func, **self.val_fix)
 
     def get_sim_kwargs(self, vector):
         """Generate keyword-args for simulation."""
         # if there is a dummy parameter it will be skipped automatically
         for i, para in enumerate(self.para_names):
-            self.sim_kwargs[self.val_kw_names[para]] = self.fit_func[para](
-                vector[i]
-            )
+            self.sim_kwargs[para] = self.fit_func[para][1](vector[i])
         return self.sim_kwargs
 
     def parameters(self):

--- a/welltestpy/estimate/steady_lib.py
+++ b/welltestpy/estimate/steady_lib.py
@@ -40,8 +40,7 @@ class SteadyPumping:
         The given type-curve. Output will be reshaped to flat array.
     val_ranges : :class:`dict`
         Dictionary containing the fit-ranges for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Ranges should be a tuple containing min and max value.
     make_steady : :class:`bool`, optional
         State if the tests should be converted to steady observations.
@@ -49,24 +48,21 @@ class SteadyPumping:
         Default: True
     val_fix : :class:`dict` or :any:`None`
         Dictionary containing fixed values for the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
+        Names should be as in the type-curve signature.
         Default: None
-    fit_type : :class:`dict` or :any:`None`
-        Dictionary containing fitting type for each value in the type-curve.
-        Names should be as in the type-curve signature
-        or replaced in val_kw_names.
-        fit_type can be "lin", "log" (np.exp(val) will be used)
-        or a callable function.
-        By default, values will be fit linearly.
+    val_fit_type : :class:`dict` or :any:`None`
+        Dictionary containing fitting transformation type for each value.
+        Names should be as in the type-curve signature.
+        val_fit_type can be "lin", "log", "exp", "sqrt", "quad", "inv"
+        or a tuple of two callable functions where the
+        first is the transformation and the second is its inverse.
+        "log" is for example equivalent to ``(np.log, np.exp)``.
+        By default, values will be fitted linear.
         Default: None
-    val_kw_names : :class:`dict` or :any:`None`
-        Dictionary containing keyword names in the type-curve for each value.
-
-            {value-name: kwargs-name in type_curve}
-
-        This is useful if fitting is not done by linear values.
-        By default, parameter names will be value names.
+    val_fit_name : :class:`dict` or :any:`None`
+        Display name of the fitting transformation.
+        Will be the val_fit_type string if it is a predefined one,
+        or ``f`` if it is a given callable as default for each value.
         Default: None
     val_plot_names : :class:`dict` or :any:`None`
         Dictionary containing keyword names in the type-curve for each value.
@@ -94,22 +90,19 @@ class SteadyPumping:
         val_ranges,
         make_steady=True,
         val_fix=None,
-        fit_type=None,
-        val_kw_names=None,
+        val_fit_type=None,
+        val_fit_name=None,
         val_plot_names=None,
         testinclude=None,
         generate=False,
     ):
         val_fix = {} if val_fix is None else val_fix
-        fit_type = {} if fit_type is None else fit_type
-        val_kw_names = {} if val_kw_names is None else val_kw_names
-        val_plot_names = {} if val_plot_names is None else val_plot_names
         self.setup_kw = {
             "type_curve": type_curve,
             "val_ranges": val_ranges,
             "val_fix": val_fix,
-            "fit_type": fit_type,
-            "val_kw_names": val_kw_names,
+            "val_fit_type": val_fit_type,
+            "val_fit_name": val_fit_name,
             "val_plot_names": val_plot_names,
         }
         """:class:`dict`: TypeCurve Spotpy Setup definition"""
@@ -275,19 +268,15 @@ class SteadyPumping:
             sensitivity analysis.
             Default: False
         """
-        self.extra_kw_names = {
-            "Qw": prate_kw,
-            "rad": rad_kw,
-            "r_ref": r_ref_kw,
-            "h_ref": h_ref_kw,
-        }
-        self.setup_kw["val_fix"].setdefault(prate_kw, self.prate)
-        self.setup_kw["val_fix"].setdefault(rad_kw, self.rad)
-        self.setup_kw["val_fix"].setdefault(r_ref_kw, self.r_ref)
-        self.setup_kw["val_fix"].setdefault(h_ref_kw, self.h_ref)
-        self.setup_kw.setdefault("data", self.data)
-        self.setup_kw["dummy"] = dummy
-        self.setup = spotpylib.TypeCurve(**self.setup_kw)
+        self.extra_kw_names = {"rad": rad_kw}
+        setup_kw = dcopy(self.setup_kw)  # create a copy here
+        setup_kw["val_fix"].setdefault(prate_kw, self.prate)
+        setup_kw["val_fix"].setdefault(rad_kw, self.rad)
+        setup_kw["val_fix"].setdefault(r_ref_kw, self.r_ref)
+        setup_kw["val_fix"].setdefault(h_ref_kw, self.h_ref)
+        setup_kw.setdefault("data", self.data)
+        setup_kw["dummy"] = dummy
+        self.setup = spotpylib.TypeCurve(**setup_kw)
 
     def run(
         self,
@@ -389,7 +378,11 @@ class SteadyPumping:
 
         # generate the parameter-names for plotting
         paranames = dcopy(self.setup.para_names)
-        paralabels = [self.setup.val_plot_names[name] for name in paranames]
+        paralabels = []
+        for name in paranames:
+            p_label = self.setup.val_plot_names[name]
+            fit_n = self.setup.val_fit_name[name]
+            paralabels.append(f"{fit_n}({p_label})" if fit_n else p_label)
 
         if parallel == "mpi":
             # send the dbname of rank0
@@ -436,8 +429,9 @@ class SteadyPumping:
             header = []
             for name in void_names:
                 para.append(para_opt[0][name])
-                header.append(name[3:])
-                self.estimated_para[header[-1]] = para[-1]
+                fit_n = self.setup.val_fit_name[name[3:]]
+                header.append(f"{fit_n}-{name[3:]}" if fit_n else name[3:])
+                self.estimated_para[name[3:]] = para[-1]
             np.savetxt(paraname, para, header=" ".join(header))
             # plot the estimation-results
             plotter.plotparatrace(
@@ -554,7 +548,11 @@ class SteadyPumping:
 
         # generate the parameter-names for plotting
         paranames = dcopy(self.setup.para_names)
-        paralabels = [self.setup.val_plot_names[name] for name in paranames]
+        paralabels = []
+        for name in paranames:
+            p_label = self.setup.val_plot_names[name]
+            fit_n = self.setup.val_fit_name[name]
+            paralabels.append(f"{fit_n}({p_label})" if fit_n else p_label)
 
         if self.setup.dummy:
             paranames.append("dummy")

--- a/welltestpy/process/processlib.py
+++ b/welltestpy/process/processlib.py
@@ -269,7 +269,7 @@ def cooper_jacob_correction(observation, sat_thickness):
     head = observation.observation
 
     # cooper and jacob correction
-    head = head - (head ** 2) / (2 * sat_thickness)
+    head = head - (head**2) / (2 * sat_thickness)
 
     # return new observation
     observation(observation=head)

--- a/welltestpy/tools/diagnostic_plots.py
+++ b/welltestpy/tools/diagnostic_plots.py
@@ -100,8 +100,8 @@ def diagnostic_plot_pump_test(
             min_e = -np.inf
         else:
             min_e = int(np.floor(np.log10(min_v)))
-        ax.set_ylim(10.0 ** min_e, 10.0 ** max_e)
-        yticks = [0 if min_v < linthresh_head else 10.0 ** min_e]
+        ax.set_ylim(10.0**min_e, 10.0**max_e)
+        yticks = [0 if min_v < linthresh_head else 10.0**min_e]
         thresh_e = int(np.floor(np.log10(linthresh_head)))
         first_e = thresh_e if min_v < linthresh_head else (min_e + 1)
         yticks += list(10.0 ** np.arange(first_e, max_e + 1))

--- a/welltestpy/tools/plotter.py
+++ b/welltestpy/tools/plotter.py
@@ -834,9 +834,7 @@ def plotparatrace(
             ax.set_xlim(0, rep)
             ax.margins(y=0.2)
             ax.xaxis.set_ticks(xticks)
-            ax.set_ylabel(
-                parameterlabels[j], fontsize="large"
-            )
+            ax.set_ylabel(parameterlabels[j], fontsize="large")
         ax.set_xlabel("Iterations", fontsize="large")
         fig.align_ylabels(axes)
         fig.tight_layout()
@@ -886,8 +884,8 @@ def plotsensitivity(
 def _scatter_matrix(data, label, fig=None):
     data = np.array(data, ndmin=2, dtype=float)
     n = len(data)
-    axes = np.empty(n ** 2, dtype=object)
-    for i in range(n ** 2):
+    axes = np.empty(n**2, dtype=object)
+    for i in range(n**2):
         fig, axes[i] = _get_fig_ax(fig, figsize=(8, 8), sub_args=(n, n, i + 1))
     axes = axes.reshape(n, n)
 

--- a/welltestpy/tools/plotter.py
+++ b/welltestpy/tools/plotter.py
@@ -725,8 +725,8 @@ def plotfit_steady(
                 transform=axins.transAxes,
             )
         for ri, re in enumerate(rad):
-            h = plot_f(**{extra["rad"]: re}).reshape(-1)
-            h1 = data[ri]
+            h = np.asarray(plot_f(**{extra["rad"]: re})).reshape(-1)
+            h1 = np.asarray(data[ri]).reshape(-1)
             color = clrs[(test_name.index(radnames[ri, 0]) + 2) % clr_n]
             if radnames[ri, 0] == radnames[ri, 1]:
                 label = "test at '{}'".format(radnames[ri, 0])
@@ -808,9 +808,10 @@ def plotparatrace(
             plt.rcParams.update({"font.size": font_size})
         clrs = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         fig = _get_fig_ax(fig, ax=False, figsize=(15, 3 * rows))
-
+        axes = []
         for j in range(rows):
             ax = fig.add_subplot(rows, 1, 1 + j)
+            axes.append(ax)
             data = result["par" + parameternames[j]]
 
             ax.plot(data, "-", color=clrs[0])
@@ -831,15 +832,13 @@ def plotparatrace(
                 xticks = np.linspace(0, 1, 11) * len(data)
 
             ax.set_xlim(0, rep)
-            ax.set_ylim(
-                np.min(data) - 0.1 * np.max(abs(data)),
-                np.max(data) + 0.1 * np.max(abs(data)),
-            )
+            ax.margins(y=0.2)
             ax.xaxis.set_ticks(xticks)
             ax.set_ylabel(
-                parameterlabels[j], rotation=0, fontsize="large", labelpad=10
+                parameterlabels[j], fontsize="large"
             )
-
+        ax.set_xlabel("Iterations", fontsize="large")
+        fig.align_ylabels(axes)
         fig.tight_layout()
         if plotname is not None:
             fig.savefig(plotname, format="pdf", bbox_inches="tight")

--- a/welltestpy/tools/trilib.py
+++ b/welltestpy/tools/trilib.py
@@ -322,7 +322,7 @@ def _xvalue(a, b, c):
     lying on the x-axes, a is the distance of the unknown point to the origen
     and b is the distance of the unknown point to the righter given point
     """
-    return (a ** 2 + c ** 2 - b ** 2) / (2 * c)
+    return (a**2 + c**2 - b**2) / (2 * c)
 
 
 def _yvalue(b, a, c):
@@ -338,7 +338,7 @@ def _yvalue(b, a, c):
         return 0.0, -0.0
 
     res = 2 * ((a * b) ** 2 + (a * c) ** 2 + (b * c) ** 2)
-    res -= a ** 4 + b ** 4 + c ** 4
+    res -= a**4 + b**4 + c**4
     # in case of numerical errors set res to 0 (hope you check validity before)
     res = max(res, 0.0)
     res = np.sqrt(res)


### PR DESCRIPTION
Closes #29 

- new arguments `val_fit_type` and `val_fit_name` for all estimators to select fitting transformation
- `val_fit_name` will be incorporated into the generated plots and the header of the estimation result file
- value names for all arguments in the estimators now need to match the call signatures of the used type-curves
- minor fixes for the plotting routines and the estimators